### PR TITLE
Feature Single-id to handle jobs that should only run once

### DIFF
--- a/examples/twitter/TwitterClient/build.gradle
+++ b/examples/twitter/TwitterClient/build.gradle
@@ -53,7 +53,7 @@ android {
 
     dependencies {
         compile 'de.greenrobot:eventbus:2.1.0-beta-1'
-        compile 'org.twitter4j:twitter4j-core:3.0.5'
+        compile 'org.twitter4j:twitter4j-core:4.0.4'
         compile 'com.birbit:android-priority-jobqueue:1.3.3'
         compile files('external-libs/greenDAO.jar')
     }

--- a/examples/twitter/TwitterClient/build.gradle
+++ b/examples/twitter/TwitterClient/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 
@@ -44,11 +44,11 @@ tasks.create(name: "runTwitter", type: RunApk){
 }
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "23"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 17
+        targetSdkVersion 23
     }
 
     dependencies {

--- a/examples/twitter/TwitterClient/build.gradle
+++ b/examples/twitter/TwitterClient/build.gradle
@@ -54,7 +54,7 @@ android {
     dependencies {
         compile 'de.greenrobot:eventbus:2.1.0-beta-1'
         compile 'org.twitter4j:twitter4j-core:4.0.4'
-        compile 'com.birbit:android-priority-jobqueue:1.3.3'
+        compile project(':jobqueue')
         compile files('external-libs/greenDAO.jar')
     }
 

--- a/examples/twitter/TwitterClient/settings.gradle
+++ b/examples/twitter/TwitterClient/settings.gradle
@@ -1,0 +1,2 @@
+include ':jobqueue'
+project(':jobqueue').projectDir = new File(settingsDir, '../../../jobqueue')

--- a/jobqueue/src/main/java/com/path/android/jobqueue/Job.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/Job.java
@@ -22,6 +22,7 @@ abstract public class Job implements Serializable {
 
     private boolean requiresNetwork;
     private String groupId;
+    private String singleId;
     private boolean persistent;
     private Set<String> readonlyTags;
 
@@ -42,6 +43,7 @@ abstract public class Job implements Serializable {
         this.requiresNetwork = params.doesRequireNetwork();
         this.persistent = params.isPersistent();
         this.groupId = params.getGroupId();
+        this.singleId = params.getSingleId();
         this.priority = params.getPriority();
         this.delayInMs = params.getDelayMs();
         final Set<String> tags = params.getTags();
@@ -76,6 +78,7 @@ abstract public class Job implements Serializable {
     private void writeObject(ObjectOutputStream oos) throws IOException {
         oos.writeBoolean(requiresNetwork);
         oos.writeObject(groupId);
+        oos.writeObject(singleId);
         oos.writeBoolean(persistent);
         final int tagCount = readonlyTags == null ? 0 : readonlyTags.size();
         oos.writeInt(tagCount);
@@ -90,6 +93,7 @@ abstract public class Job implements Serializable {
     private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
         requiresNetwork = ois.readBoolean();
         groupId = (String) ois.readObject();
+        singleId = (String) ois.readObject();
         persistent = ois.readBoolean();
         final int tagCount = ois.readInt();
         if (tagCount > 0) {
@@ -250,6 +254,16 @@ abstract public class Job implements Serializable {
      */
     public final String getRunGroupId() {
         return groupId;
+    }
+
+    /**
+     * Some jobs only need a single instance to be queued to run. For instance, if a user has made several changes
+     * to a resource while offline, you can save every change locally during {@link #onAdded()}, but
+     * only update the resource remotely once with the latest changes.
+     * @return
+     */
+    public final String getRunSingleId() {
+        return singleId;
     }
 
     /**

--- a/jobqueue/src/main/java/com/path/android/jobqueue/Job.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/Job.java
@@ -113,7 +113,11 @@ abstract public class Job implements Serializable {
 
     /**
      * Called when the job is added to disk and committed.
-     * This means job will eventually run. This is a good time to update local database and dispatch events.
+     * This means job will eventually run except in the case described below.
+     * This is a good time to update local database and dispatch events.
+     * <p>
+     * If the job has a singleId and another job with the same singleId is already queued and not yet
+     * running, only the previous job will run.
      * <p>
      * Changes to this class will not be preserved if your job is persistent !!!
      * <p>

--- a/jobqueue/src/main/java/com/path/android/jobqueue/JobHolder.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/JobHolder.java
@@ -38,6 +38,7 @@ public class JobHolder {
     protected Long id;
     protected int priority;
     protected String groupId;
+    protected String singleId;
     protected int runCount;
     /**
      * job will be delayed until this nanotime
@@ -59,16 +60,18 @@ public class JobHolder {
      * @param id               Unique ID for the job. Should be unique per queue
      * @param priority         Higher is better
      * @param groupId          which group does this job belong to? default null
+     * @param singleId         which group should only be queued to run once? default null
      * @param runCount         Incremented each time job is fetched to run, initial value should be 0
      * @param job              Actual job to run
      * @param createdNs        System.nanotime
      * @param delayUntilNs     System.nanotime value where job can be run the very first time
      * @param runningSessionId
      */
-    public JobHolder(Long id, int priority, String groupId, int runCount, Job job, long createdNs, long delayUntilNs, long runningSessionId) {
+    public JobHolder(Long id, int priority, String groupId, String singleId, int runCount, Job job, long createdNs, long delayUntilNs, long runningSessionId) {
         this.id = id;
         this.priority = priority;
         this.groupId = groupId;
+        this.singleId = singleId;
         this.runCount = runCount;
         this.createdNs = createdNs;
         this.delayUntilNs = delayUntilNs;
@@ -80,11 +83,11 @@ public class JobHolder {
     }
 
     public JobHolder(int priority, Job job, long runningSessionId) {
-        this(null, priority, null, 0, job, System.nanoTime(), Long.MIN_VALUE, runningSessionId);
+        this(null, priority, null, null, 0, job, System.nanoTime(), Long.MIN_VALUE, runningSessionId);
     }
 
     public JobHolder(int priority, Job job, long delayUntilNs, long runningSessionId) {
-        this(null, priority, job.getRunGroupId(), 0, job, System.nanoTime(), delayUntilNs, runningSessionId);
+        this(null, priority, job.getRunGroupId(), job.getRunSingleId(), 0, job, System.nanoTime(), delayUntilNs, runningSessionId);
     }
 
     /**
@@ -158,6 +161,10 @@ public class JobHolder {
     }
 
     public String getGroupId() {
+        return groupId;
+    }
+
+    public String getSingleId() {
         return groupId;
     }
 

--- a/jobqueue/src/main/java/com/path/android/jobqueue/JobHolder.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/JobHolder.java
@@ -165,7 +165,7 @@ public class JobHolder {
     }
 
     public String getSingleId() {
-        return groupId;
+        return singleId;
     }
 
     public Set<String> getTags() {

--- a/jobqueue/src/main/java/com/path/android/jobqueue/JobQueue.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/JobQueue.java
@@ -95,6 +95,16 @@ public interface JobQueue {
             Collection<Long> excludeIds, String... tags);
 
     /**
+     * Returns all jobs not excluded by the conditions passed.
+     *
+     * @param excludeCancelled If true, cancelled jobs will not be returned. A job may be in cancelled
+     *                        state if a cancel request has arrived but it has not been removed from
+     *                        queue yet (e.g. still running).
+     * @param excludeIds Ids of jobs to ignore in the result
+     */
+    Set<JobHolder> findAllJobs(boolean excludeCancelled, Collection<Long> excludeIds);
+
+    /**
      * Called when a job is cancelled by the user.
      * <p/>
      * It is important to not return this job from queries anymore.

--- a/jobqueue/src/main/java/com/path/android/jobqueue/Params.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/Params.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 public class Params {
     private boolean requiresNetwork = false;
     private String groupId = null;
+    private String singleId = null;
     private boolean persistent = false;
     private int priority;
     private long delayMs;
@@ -38,6 +39,18 @@ public class Params {
      */
     public Params groupBy(String groupId) {
         this.groupId = groupId;
+        return this;
+    }
+
+    /**
+     * Sets the single id. Jobs with the same single id will always get {@link Job#onAdded()}
+     * called, but {@link Job#onRun()} will only run once if there are other non-running
+     * Jobs queued.
+     * @param singleId which group this job belongs (can be null of course)
+     * @return this
+     */
+    public Params singleWith(String singleId) {
+        this.singleId = singleId;
         return this;
     }
 
@@ -77,6 +90,16 @@ public class Params {
      */
     public Params setGroupId(String groupId) {
         this.groupId = groupId;
+        return this;
+    }
+
+    /**
+     * convenience method to set single id.
+     * @param singleId
+     * @return this
+     */
+    public Params setSingleId(String singleId) {
+        this.singleId = singleId;
         return this;
     }
 
@@ -143,6 +166,10 @@ public class Params {
 
     public String getGroupId() {
         return groupId;
+    }
+
+    public String getSingleId() {
+        return singleId;
     }
 
     public boolean isPersistent() {

--- a/jobqueue/src/main/java/com/path/android/jobqueue/Params.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/Params.java
@@ -45,7 +45,7 @@ public class Params {
     /**
      * Sets the single id. Jobs with the same single id will always get {@link Job#onAdded()}
      * called, but {@link Job#onRun()} will only run once if there are other non-running
-     * Jobs queued.
+     * Jobs queued. You will probably also want to use {@link #groupBy(String)}.
      * @param singleId which group this job belongs (can be null of course)
      * @return this
      */

--- a/jobqueue/src/main/java/com/path/android/jobqueue/cachedQueue/CachedJobQueue.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/cachedQueue/CachedJobQueue.java
@@ -106,6 +106,11 @@ public class CachedJobQueue implements JobQueue {
     }
 
     @Override
+    public Set<JobHolder> findAllJobs(boolean excludeCancelled, Collection<Long> exclude) {
+        return delegate.findAllJobs(excludeCancelled, exclude);
+    }
+
+    @Override
     public void onJobCancelled(JobHolder holder) {
         delegate.onJobCancelled(holder);
     }

--- a/jobqueue/src/main/java/com/path/android/jobqueue/executor/JobConsumerExecutor.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/executor/JobConsumerExecutor.java
@@ -180,6 +180,23 @@ public class JobConsumerExecutor {
     /**
      * Excludes cancelled jobs
      */
+    public Set<JobHolder> findRunning(boolean persistent) {
+        Set<JobHolder> result = new HashSet<JobHolder>();
+        synchronized (runningJobHolders) {
+            for (JobHolder holder : runningJobHolders.values()) {
+                if (persistent == holder.getJob().isPersistent()) {
+                    if (!holder.isCancelled()) {
+                        result.add(holder);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Excludes cancelled jobs
+     */
     public Set<JobHolder> findRunningByTags(TagConstraint constraint, String[] tags,
             boolean persistent) {
         Set<JobHolder> result = new HashSet<JobHolder>();

--- a/jobqueue/src/main/java/com/path/android/jobqueue/nonPersistentQueue/JobSet.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/nonPersistentQueue/JobSet.java
@@ -16,6 +16,7 @@ public interface JobSet {
     JobHolder findById(long id);
     Set<JobHolder> findByTags(TagConstraint constraint, Collection<Long> exclude,
             String... tags);
+    Set<JobHolder> findAll(Collection<Long> exclude);
     boolean offer(JobHolder holder);
     boolean remove(JobHolder holder);
     void clear();

--- a/jobqueue/src/main/java/com/path/android/jobqueue/nonPersistentQueue/MergedQueue.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/nonPersistentQueue/MergedQueue.java
@@ -222,6 +222,14 @@ abstract public class MergedQueue implements JobSet {
         return jobs;
     }
 
+    @Override
+    public Set<JobHolder> findAll(Collection<Long> exclude) {
+        Set<JobHolder> jobs = new HashSet<JobHolder>();
+        jobs.addAll(queue0.findAll(exclude));
+        jobs.addAll(queue1.findAll(exclude));
+        return jobs;
+    }
+
     /**
      * simple enum to identify queues
      */

--- a/jobqueue/src/main/java/com/path/android/jobqueue/nonPersistentQueue/NonPersistentJobSet.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/nonPersistentQueue/NonPersistentJobSet.java
@@ -117,6 +117,16 @@ public class NonPersistentJobSet implements JobSet {
         return jobs;
     }
 
+    @Override
+    public Set<JobHolder> findAll(Collection<Long> exclude) {
+        Set<JobHolder> jobs = new HashSet<JobHolder>();
+        jobs.addAll(set);
+        if (exclude != null) {
+            removeIds(jobs, exclude);
+        }
+        return jobs;
+    }
+
     private void removeIds(Set<JobHolder> mainSet, Collection<Long> ids) {
         final Iterator<JobHolder> itr = mainSet.iterator();
         while (itr.hasNext()) {

--- a/jobqueue/src/main/java/com/path/android/jobqueue/nonPersistentQueue/NonPersistentPriorityQueue.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/nonPersistentQueue/NonPersistentPriorityQueue.java
@@ -119,6 +119,12 @@ public class NonPersistentPriorityQueue implements JobQueue {
     }
 
     @Override
+    public Set<JobHolder> findAllJobs(boolean excludeCancelled, Collection<Long> exclude) {
+        //we ignore excludeCancelled because we remove them as soon as they are cancelled
+        return jobs.findAll(exclude);
+    }
+
+    @Override
     public void onJobCancelled(JobHolder holder) {
         // we can remove instantly.
         remove(holder);

--- a/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/DbOpenHelper.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/DbOpenHelper.java
@@ -62,9 +62,16 @@ public class DbOpenHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase sqLiteDatabase, int oldVersion, int newVersion) {
-        sqLiteDatabase.execSQL(SqlHelper.drop(JOB_HOLDER_TABLE_NAME));
-        sqLiteDatabase.execSQL(SqlHelper.drop(JOB_TAGS_TABLE_NAME));
-        sqLiteDatabase.execSQL("DROP INDEX IF EXISTS " + TAG_INDEX_NAME);
-        onCreate(sqLiteDatabase);
+        if (oldVersion < 4) {
+            sqLiteDatabase.execSQL(SqlHelper.drop(JOB_HOLDER_TABLE_NAME));
+            sqLiteDatabase.execSQL(SqlHelper.drop(JOB_TAGS_TABLE_NAME));
+            sqLiteDatabase.execSQL("DROP INDEX IF EXISTS " + TAG_INDEX_NAME);
+            onCreate(sqLiteDatabase);
+        } else if (oldVersion == 4) {
+            //We add single_id column in version 5
+            String addSingleIdColQuery = "ALTER TABLE " + JOB_HOLDER_TABLE_NAME
+                    + " ADD COLUMN `" + SINGLE_ID_COLUMN.columnName + "` " + SINGLE_ID_COLUMN.type;
+            sqLiteDatabase.execSQL(addSingleIdColQuery);
+        }
     }
 }

--- a/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/DbOpenHelper.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/DbOpenHelper.java
@@ -8,7 +8,7 @@ import android.database.sqlite.SQLiteOpenHelper;
  * Helper class for {@link SqliteJobQueue} to handle database connection
  */
 public class DbOpenHelper extends SQLiteOpenHelper {
-    private static final int DB_VERSION = 4;
+    private static final int DB_VERSION = 5;
     /*package*/ static final String JOB_HOLDER_TABLE_NAME = "job_holder";
     /*package*/ static final String JOB_TAGS_TABLE_NAME = "job_holder_tags";
     /*package*/ static final SqlHelper.Property ID_COLUMN = new SqlHelper.Property("_id", "integer", 0);
@@ -20,11 +20,12 @@ public class DbOpenHelper extends SQLiteOpenHelper {
     /*package*/ static final SqlHelper.Property DELAY_UNTIL_NS_COLUMN = new SqlHelper.Property("delay_until_ns", "long", 6);
     /*package*/ static final SqlHelper.Property RUNNING_SESSION_ID_COLUMN = new SqlHelper.Property("running_session_id", "long", 7);
     /*package*/ static final SqlHelper.Property REQUIRES_NETWORK_COLUMN = new SqlHelper.Property("requires_network", "integer", 8);
+    /*package*/ static final SqlHelper.Property SINGLE_ID_COLUMN = new SqlHelper.Property("single_id", "text", 9);
     /*package*/ static final SqlHelper.Property TAGS_ID_COLUMN = new SqlHelper.Property("_id", "integer", 0);
     /*package*/ static final SqlHelper.Property TAGS_JOB_ID_COLUMN = new SqlHelper.Property("job_id", "integer", 1, new SqlHelper.ForeignKey(JOB_HOLDER_TABLE_NAME, ID_COLUMN.columnName));
     /*package*/ static final SqlHelper.Property TAGS_NAME_COLUMN = new SqlHelper.Property("tag_name", "text", 2);
 
-    /*package*/ static final int COLUMN_COUNT = 9;
+    /*package*/ static final int COLUMN_COUNT = 10;
     /*package*/ static final int TAGS_COLUMN_COUNT = 3;
 
     static final String TAG_INDEX_NAME = "TAG_NAME_INDEX";
@@ -44,7 +45,8 @@ public class DbOpenHelper extends SQLiteOpenHelper {
                 CREATED_NS_COLUMN,
                 DELAY_UNTIL_NS_COLUMN,
                 RUNNING_SESSION_ID_COLUMN,
-                REQUIRES_NETWORK_COLUMN
+                REQUIRES_NETWORK_COLUMN,
+                SINGLE_ID_COLUMN
         );
         sqLiteDatabase.execSQL(createQuery);
 

--- a/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/SqlHelper.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/SqlHelper.java
@@ -101,6 +101,18 @@ public class SqlHelper {
         return query.toString();
     }
 
+    public String createFindAllQuery(int numberOfExcludeIds) {
+        StringBuilder query = new StringBuilder();
+        query.append("SELECT * FROM ").append(tableName);
+        if (numberOfExcludeIds > 0) {
+            String idPlaceHolders = createPlaceholders(numberOfExcludeIds);
+            query.append(" WHERE ").append(DbOpenHelper.ID_COLUMN.columnName)
+                    .append(" NOT IN(").append(idPlaceHolders).append(")");
+        }
+
+        return query.toString();
+    }
+
     public static String drop(String tableName) {
         return "DROP TABLE IF EXISTS " + tableName;
     }

--- a/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/SqliteJobQueue.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/SqliteJobQueue.java
@@ -238,15 +238,38 @@ public class SqliteJobQueue implements JobQueue {
         final String query = sqlHelper.createFindByTagsQuery(tagConstraint,
                 excludeCount, tags.length);
         JqLog.d(query);
-        final String[] args;
+        final String[] args = getFindJobsArgs(excludeCancelled, exclude, excludeCount, tags);
+        addJobsFromQuery(query, args, jobs);
+        return jobs;
+    }
+
+    @Override
+    public Set<JobHolder> findAllJobs(boolean excludeCancelled, Collection<Long> exclude) {
+        Set<JobHolder> jobs = new HashSet<JobHolder>();
+        int excludeCount = exclude == null ? 0 : exclude.size();
+        if (excludeCancelled) {
+            excludeCount += pendingCancelations.size();
+        }
+        final String query = sqlHelper.createFindAllQuery(excludeCount);
+        JqLog.d(query);
+        final String[] args = getFindJobsArgs(excludeCancelled, exclude, excludeCount, new String[]{});
+        addJobsFromQuery(query, args, jobs);
+        return jobs;
+    }
+
+    private String[] getFindJobsArgs(boolean excludeCancelled, Collection<Long> excludeIds,
+                                     int excludeCount, String[] tags) {
+        String[] args;
         if (excludeCount == 0) {
             args = tags;
         } else {
             args = new String[excludeCount + tags.length];
             System.arraycopy(tags, 0, args, 0, tags.length);
             int i = tags.length;
-            for (Long ex : exclude) {
-                args[i ++] = ex.toString();
+            if (excludeIds != null) {
+                for (Long ex : excludeIds) {
+                    args[i ++] = ex.toString();
+                }
             }
             if (excludeCancelled) {
                 for (Long ex : pendingCancelations) {
@@ -254,17 +277,20 @@ public class SqliteJobQueue implements JobQueue {
                 }
             }
         }
+        return args;
+    }
+
+    private void addJobsFromQuery(String query, String[] args, Set<JobHolder> jobs) {
         Cursor cursor = db.rawQuery(query, args);
         try {
             while (cursor.moveToNext()) {
                 jobs.add(createJobHolderFromCursor(cursor));
             }
         } catch (InvalidJobException e) {
-            JqLog.e(e, "invalid job found by tags.");
+            JqLog.e(e, "invalid job found from query.");
         } finally {
             cursor.close();
         }
-        return jobs;
     }
 
     @Override

--- a/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/SqliteJobQueue.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/SqliteJobQueue.java
@@ -112,6 +112,9 @@ public class SqliteJobQueue implements JobQueue {
         if(jobHolder.getGroupId() != null) {
             stmt.bindString(DbOpenHelper.GROUP_ID_COLUMN.columnIndex + 1, jobHolder.getGroupId());
         }
+        if(jobHolder.getSingleId() != null) {
+            stmt.bindString(DbOpenHelper.SINGLE_ID_COLUMN.columnIndex + 1, jobHolder.getSingleId());
+        }
         stmt.bindLong(DbOpenHelper.RUN_COUNT_COLUMN.columnIndex + 1, jobHolder.getRunCount());
         byte[] job = getSerializeJob(jobHolder);
         if (job != null) {
@@ -410,6 +413,7 @@ public class SqliteJobQueue implements JobQueue {
                 cursor.getLong(DbOpenHelper.ID_COLUMN.columnIndex),
                 cursor.getInt(DbOpenHelper.PRIORITY_COLUMN.columnIndex),
                 cursor.getString(DbOpenHelper.GROUP_ID_COLUMN.columnIndex),
+                cursor.getString(DbOpenHelper.SINGLE_ID_COLUMN.columnIndex),
                 cursor.getInt(DbOpenHelper.RUN_COUNT_COLUMN.columnIndex),
                 job,
                 cursor.getLong(DbOpenHelper.CREATED_NS_COLUMN.columnIndex),

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/JobConsumerExecutorTest.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/JobConsumerExecutorTest.java
@@ -1,0 +1,63 @@
+package com.path.android.jobqueue.test.jobmanager;
+
+import com.path.android.jobqueue.JobHolder;
+import com.path.android.jobqueue.JobManager;
+import com.path.android.jobqueue.Params;
+import com.path.android.jobqueue.executor.JobConsumerExecutor;
+import com.path.android.jobqueue.test.jobs.DummyJob;
+
+import org.fest.reflect.core.Reflection;
+import org.fest.reflect.method.Invoker;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = com.path.android.jobqueue.BuildConfig.class)
+public class JobConsumerExecutorTest extends JobManagerTestBase {
+
+    protected Invoker<Void> getOnBeforeRunMethod(JobConsumerExecutor executor) {
+        return Reflection.method("onBeforeRun").withParameterTypes(JobHolder.class).in(executor);
+    }
+
+    protected Invoker<Void> getOnAfterRunMethod(JobConsumerExecutor executor) {
+        return Reflection.method("onAfterRun").withParameterTypes(JobHolder.class).in(executor);
+    }
+
+    @Test
+    public void testFindAllPersistent() throws Exception {
+        testFindAll(true);
+    }
+
+    @Test
+    public void testFindAllNonPersistent() throws Exception {
+        testFindAll(false);
+    }
+
+    private void testFindAll(boolean persistent) {
+        JobManager jobManager = createJobManager();
+        jobManager.stop();
+        JobConsumerExecutor executor = getConsumerExecutor(jobManager);
+        assertThat("empty executor should return 0", executor.findRunning(persistent).size(), is(0));
+
+        DummyJob dummyJob1 = new DummyJob(new Params(0).setPersistent(persistent));
+        jobManager.addJob(dummyJob1);
+        JobHolder jobHolder1 = getNextJobMethod(jobManager).invoke();
+        getOnBeforeRunMethod(executor).invoke(jobHolder1);
+        assertThat("should return inserted job", executor.findRunning(persistent).size(), is(1));
+
+        DummyJob dummyJob2 = new DummyJob(new Params(0).setPersistent(!persistent));
+        jobManager.addJob(dummyJob2);
+        JobHolder jobHolder2 = getNextJobMethod(jobManager).invoke();
+        getOnBeforeRunMethod(executor).invoke(jobHolder2);
+        assertThat("should not increase count if persistent is " + persistent,
+                executor.findRunning(persistent).size(), is(1));
+
+        getOnAfterRunMethod(executor).invoke(jobHolder1);
+        assertThat("should not return job if stopped running", executor.findRunning(persistent).size(), is(0));
+    }
+}

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/SingleIdTest.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/SingleIdTest.java
@@ -1,0 +1,132 @@
+package com.path.android.jobqueue.test.jobmanager;
+
+import com.path.android.jobqueue.JobHolder;
+import com.path.android.jobqueue.JobManager;
+import com.path.android.jobqueue.Params;
+import com.path.android.jobqueue.executor.JobConsumerExecutor;
+import com.path.android.jobqueue.test.jobs.DummyJob;
+
+import org.fest.reflect.core.Reflection;
+import org.fest.reflect.method.Invoker;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = com.path.android.jobqueue.BuildConfig.class)
+public class SingleIdTest extends JobManagerTestBase {
+
+    protected Invoker<Void> getOnBeforeRunMethod(JobConsumerExecutor executor) {
+        return Reflection.method("onBeforeRun").withParameterTypes(JobHolder.class).in(executor);
+    }
+
+    protected Invoker<Void> getOnAfterRunMethod(JobConsumerExecutor executor) {
+        return Reflection.method("onAfterRun").withParameterTypes(JobHolder.class).in(executor);
+    }
+
+    @Test
+    public void testSingleIdPersistent() throws Exception {
+        testSingleId(true);
+    }
+
+    @Test
+    public void testSingleIdNonPersistent() throws Exception {
+        testSingleId(false);
+    }
+
+    private void testSingleId(boolean persistent) {
+        JobManager jobManager = createJobManager();
+        Invoker<JobHolder> nextJobMethod = getNextJobMethod(jobManager);
+        jobManager.stop();
+        String singleId = "forks";
+
+        DummyJob dummyJob1 = new DummyJob(new Params(0).setPersistent(persistent).setSingleId(singleId));
+        long jobId1 = jobManager.addJob(dummyJob1);
+
+        DummyJob dummyJob2 = new DummyJob(new Params(0).setPersistent(persistent));
+        long jobId2 = jobManager.addJob(dummyJob2);
+        assertThat("should get a new id if doesn't have singleId", jobId2, is(not(jobId1)));
+
+        DummyJob dummyJob3 = new DummyJob(new Params(0).setPersistent(persistent).setSingleId("otherId"));
+        long jobId3 = jobManager.addJob(dummyJob3);
+        assertThat("should get a new id if different singleId", jobId3, is(not(jobId1)));
+
+        DummyJob dummyJob4 = new DummyJob(new Params(0).setPersistent(persistent).setSingleId(singleId));
+        long jobId4 = jobManager.addJob(dummyJob4);
+        assertThat("should get same id with same singleId", jobId4, is(jobId1));
+
+        assertThat("should return the same id", nextJobMethod.invoke().getId(), is(jobId4));
+        assertThat("should return the same id", nextJobMethod.invoke().getId(), is(jobId2));
+        assertThat("should return the same id", nextJobMethod.invoke().getId(), is(jobId3));
+        assertThat("should return the same id", nextJobMethod.invoke(), is(nullValue()));
+    }
+
+    @Test
+    public void testSingleIdRunningPersistent() throws Exception {
+        testSingleIdRunning(true);
+    }
+
+    @Test
+    public void testSingleIdRunningNonPersistent() throws Exception {
+        testSingleIdRunning(false);
+    }
+
+    private void testSingleIdRunning(boolean persistent) throws InterruptedException {
+        JobManager jobManager = createJobManager();
+        jobManager.stop();
+        String singleId = "dorks";
+        CountDownLatch latchWait = new CountDownLatch(1);
+        CountDownLatch latchRunning = new CountDownLatch(1);
+
+        DummyJob dummyJob1 = new HoldingOnRunDummyJob(
+                new Params(0).setPersistent(persistent).setSingleId(singleId).setGroupId(singleId), latchWait, latchRunning);
+        long jobId1 = jobManager.addJob(dummyJob1);
+
+        jobManager.start();
+        latchRunning.await(2, TimeUnit.SECONDS);
+        jobManager.stop();
+
+        DummyJob dummyJob2 = new DummyJob(new Params(0).setPersistent(persistent).setSingleId(singleId).setGroupId(singleId));
+        long jobId2 = jobManager.addJob(dummyJob2);
+        assertThat("should get a new id if first job is running", jobId2, is(not(jobId1)));
+
+        DummyJob dummyJob3 = new DummyJob(new Params(0).setPersistent(persistent).setSingleId(singleId).setGroupId(singleId));
+        long jobId3 = jobManager.addJob(dummyJob3);
+        assertThat("should get same id with same singleId if already queued", jobId3, is(jobId2));
+
+        latchWait.countDown();
+        jobManager.start();
+        busyDrain(jobManager, 1);
+        DummyJob dummyJob4 = new DummyJob(new Params(0).setPersistent(persistent).setSingleId(singleId).setGroupId(singleId));
+        long jobId4 = jobManager.addJob(dummyJob4);
+        assertThat("should get new id if all have run", jobId4, is(not(jobId2)));
+    }
+
+    private static class HoldingOnRunDummyJob extends DummyJob {
+
+        final CountDownLatch mLatchWait;
+        final CountDownLatch mLatchRunning;
+
+        public HoldingOnRunDummyJob(Params params, CountDownLatch latchWait, CountDownLatch latchRunning) {
+            super(params);
+            mLatchWait = latchWait;
+            mLatchRunning = latchRunning;
+        }
+
+        @Override
+        public void onRun() throws Throwable {
+            super.onRun();
+            mLatchRunning.countDown();
+            mLatchWait.await();
+        }
+    }
+}

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobqueue/JobParamsTest.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobqueue/JobParamsTest.java
@@ -20,7 +20,7 @@ public class JobParamsTest extends TestBase {
         DummyJob j2 = new DummyJob(new Params(1).groupBy("blah"));
         assertThat("group param should be understood properly", j2.getRunGroupId(), equalTo("blah"));
         DummyJob j3 = new DummyJob(new Params(1).persist());
-        assertThat("group param should be understood properly", j3.isPersistent(), equalTo(true));
+        assertThat("persist param should be understood properly", j3.isPersistent(), equalTo(true));
         DummyJob j4 = new DummyJob(new Params(1).setPersistent(false).setRequiresNetwork(false).setGroupId(null));
         assertThat("persist param should be understood properly", j4.isPersistent(), equalTo(false));
         assertThat("require network param should be understood properly", j4.requiresNetwork(), equalTo(false));

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobqueue/JobParamsTest.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobqueue/JobParamsTest.java
@@ -19,11 +19,14 @@ public class JobParamsTest extends TestBase {
         assertThat("require network param should be understood properly", j1.requiresNetwork(), equalTo(true));
         DummyJob j2 = new DummyJob(new Params(1).groupBy("blah"));
         assertThat("group param should be understood properly", j2.getRunGroupId(), equalTo("blah"));
+        DummyJob j5 = new DummyJob(new Params(1).singleWith("bloop"));
+        assertThat("single param should be understood properly", j5.getRunSingleId(), equalTo("bloop"));
         DummyJob j3 = new DummyJob(new Params(1).persist());
         assertThat("persist param should be understood properly", j3.isPersistent(), equalTo(true));
-        DummyJob j4 = new DummyJob(new Params(1).setPersistent(false).setRequiresNetwork(false).setGroupId(null));
+        DummyJob j4 = new DummyJob(new Params(1).setPersistent(false).setRequiresNetwork(false).setGroupId(null).setSingleId(null));
         assertThat("persist param should be understood properly", j4.isPersistent(), equalTo(false));
         assertThat("require network param should be understood properly", j4.requiresNetwork(), equalTo(false));
         assertThat("group param should be understood properly", j4.getRunGroupId(), nullValue());
+        assertThat("single param should be understood properly", j4.getRunSingleId(), nullValue());
     }
 }

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobqueue/JobQueueTestBase.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobqueue/JobQueueTestBase.java
@@ -318,6 +318,10 @@ public abstract class JobQueueTestBase extends TestBase {
         return Reflection.field("groupId").ofType(String.class).in(params);
     }
 
+    private org.fest.reflect.field.Invoker<String> getSingleIdField(Params params) {
+        return Reflection.field("singleId").ofType(String.class).in(params);
+    }
+
     @Test
     public void testSessionId() throws Exception {
         long sessionId = (long) (Math.random() * 100000);
@@ -759,7 +763,8 @@ public abstract class JobQueueTestBase extends TestBase {
 
     protected JobHolder createNewJobHolder(Params params) {
         long delay = getDelayMsField(params).get();
-        return new JobHolder(null, getPriorityField(params).get(), getGroupIdField(params).get(), 0, new DummyJob(params), System.nanoTime(),
+        return new JobHolder(null, getPriorityField(params).get(), getGroupIdField(params).get(),
+                getSingleIdField(params).get(), 0, new DummyJob(params), System.nanoTime(),
                 delay > 0 ? System.nanoTime() +  delay * JobManager.NS_PER_MS : JobManager.NOT_DELAYED_JOB_DELAY, JobManager.NOT_RUNNING_SESSION_ID);
     }
 

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobqueue/JobQueueTestBase.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobqueue/JobQueueTestBase.java
@@ -119,7 +119,7 @@ public abstract class JobQueueTestBase extends TestBase {
         long jobId4 = jobQueue.insert(createNewJobHolder(new Params(0).groupBy("group2")));
         long jobId5 = jobQueue.insert(createNewJobHolder(new Params(0).groupBy("group1")));
         JobHolder holder1 = jobQueue.nextJobAndIncRunCount(true, Arrays.asList(new String[]{"group2"}));
-        assertThat("first jobs should be from group group2 if group1 is excluded",
+        assertThat("first jobs should be from group group1 if group2 is excluded",
                 holder1.getJob().getRunGroupId(), equalTo("group1"));
         assertThat("correct job should be returned if groupId is provided",
                 holder1.getId(), equalTo(jobId1));


### PR DESCRIPTION
This resolves path#51 and addresses part of what was requested in #36 .

When building a job, you can pass a singleId Param, so that if another Job with the same singleId is already queued, they will only run once. This avoids having to manually use static atomic variables or other kinds of locks. It also improves from what was suggested in path#51 in that onAdded() will always be called, so you can do database operations in the JobManager's Executor (if using addJobInBackground). The feature covers the KEEP_OTHER scenario. 

Some details:
- onAdded() will still be called on every Job so that you can update the local database if necessary. 
- The ID returned from addJob() will be the same for both (or more) jobs. 
- Finally, if the previous Job with the same singleId is already running, this behavior will not apply and both jobs will be run normally.