### PR TITLE
On downgrade drop the tables instead of throwing an exception.

### DIFF
--- a/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/DbOpenHelper.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/persistentQueue/sqlite/DbOpenHelper.java
@@ -65,4 +65,9 @@ public class DbOpenHelper extends SQLiteOpenHelper {
         sqLiteDatabase.execSQL("DROP INDEX IF EXISTS " + TAG_INDEX_NAME);
         onCreate(sqLiteDatabase);
     }
+
+    @Override
+    public void onDowngrade(SQLiteDatabase sqLiteDatabase, int oldVersion, int newVersion) {
+        onUpgrade(sqLiteDatabase, oldVersion, newVersion);
+    }
 }


### PR DESCRIPTION
We recently upgraded to the current version of the job queue which has db version 4 and we were on 3. This is fine, but whenever devs switch back to branches that are still on version 3 their app crashes until they clear data because downgrade isn't implemented.

Not sure if this is your preferred style (just calling upgrade) but I can change it to whatever :)

SQLiteOpenHelper.java
```java
public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
    throw new SQLiteException("Can't downgrade database from version " + oldVersion + " to " + newVersion);
}
```