### PR TITLE
Resolve a NullPointerException and a SecurityException.

### DIFF
--- a/jobqueue/src/main/java/com/path/android/jobqueue/network/NetworkUtilImpl.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/network/NetworkUtilImpl.java
@@ -48,7 +48,6 @@ public class NetworkUtilImpl implements NetworkUtil, NetworkEventProvider {
             return false;
         }
 
-        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo netInfo = cm.getActiveNetworkInfo();
         return netInfo != null && netInfo.isConnectedOrConnecting();
     }

--- a/jobqueue/src/main/java/com/path/android/jobqueue/network/NetworkUtilImpl.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/network/NetworkUtilImpl.java
@@ -1,10 +1,12 @@
 package com.path.android.jobqueue.network;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build.VERSION;
@@ -33,6 +35,16 @@ public class NetworkUtilImpl implements NetworkUtil, NetworkEventProvider {
     @Override
     public boolean isConnected(Context context) {
         if (isDozing(context)) {
+            return false;
+        }
+
+        int permState = context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE);
+        if (permState != PackageManager.PERMISSION_GRANTED) {
+            return false;
+        }
+
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) {
             return false;
         }
 

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/MultiThreadTest.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/MultiThreadTest.java
@@ -31,8 +31,13 @@ public class MultiThreadTest extends JobManagerTestBase {
     @Test
     public void testMultiThreaded() throws Exception {
         multiThreadedJobCounter = new AtomicInteger(0);
+
+        JobManagerTestBase.DummyNetworkUtil dummyNetworkUtil = new JobManagerTestBase.DummyNetworkUtil();
+        dummyNetworkUtil.setHasNetwork(true);
+
         final JobManager jobManager = createJobManager(new Configuration.Builder(RuntimeEnvironment.application)
-            .loadFactor(3).maxConsumerCount(10));
+            .networkUtil(dummyNetworkUtil).loadFactor(3).maxConsumerCount(10));
+
         int limit = 200;
         ExecutorService executor = new ThreadPoolExecutor(20, 20, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(limit));
         final String cancelTag = "iWillBeCancelled";

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/PriorityTest.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/PriorityTest.java
@@ -22,7 +22,12 @@ public class PriorityTest extends JobManagerTestBase {
 
     @Test
     public void testPriority() throws Exception {
-        JobManager jobManager = createJobManager(new Configuration.Builder(RuntimeEnvironment.application).maxConsumerCount(1));
+        JobManagerTestBase.DummyNetworkUtil dummyNetworkUtil = new JobManagerTestBase.DummyNetworkUtil();
+        dummyNetworkUtil.setHasNetwork(true);
+
+        JobManager jobManager = createJobManager(new Configuration.Builder(RuntimeEnvironment.application)
+            .networkUtil(dummyNetworkUtil).maxConsumerCount(1));
+
         testPriority(jobManager, false);
     }
 

--- a/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/RunFailingJobTest.java
+++ b/jobqueue/src/test/java/com/path/android/jobqueue/test/jobmanager/RunFailingJobTest.java
@@ -5,6 +5,7 @@ import com.path.android.jobqueue.JobManager;
 import static org.hamcrest.CoreMatchers.*;
 
 import com.path.android.jobqueue.Params;
+import com.path.android.jobqueue.config.Configuration;
 import org.hamcrest.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +21,13 @@ public class RunFailingJobTest extends JobManagerTestBase {
     @Test
     public void runFailingJob() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        JobManager jobManager = createJobManager();
+
+        JobManagerTestBase.DummyNetworkUtil dummyNetworkUtil = new JobManagerTestBase.DummyNetworkUtil();
+        dummyNetworkUtil.setHasNetwork(true);
+
+        JobManager jobManager = createJobManager(new Configuration.Builder(RuntimeEnvironment.application)
+            .networkUtil(dummyNetworkUtil));
+
         jobManager.addJob(new Job(new Params(0).requireNetwork()) {
             @Override
             public void onAdded() {


### PR DESCRIPTION
Resolve a NullPointerException and a SecurityException in NetworkUtilImpl.

1. Add a permission check before attempting to retrieve the network info.
2. Add a check for null when retrieving the ConnectivityManager.