### PR TITLE
Thread priority

### DIFF
--- a/jobqueue/src/main/java/com/path/android/jobqueue/config/Configuration.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/config/Configuration.java
@@ -21,6 +21,7 @@ public class Configuration {
     public static final int DEFAULT_LOAD_FACTOR_PER_CONSUMER = 3;
     public static final int MAX_CONSUMER_COUNT = 5;
     public static final int MIN_CONSUMER_COUNT = 0;
+    private static final int DEFAULT_THREAD_PRIORITY = Thread.NORM_PRIORITY;
 
     private String id = DEFAULT_ID;
     private int maxConsumerCount = MAX_CONSUMER_COUNT;
@@ -32,6 +33,7 @@ public class Configuration {
     private NetworkUtil networkUtil;
     private CustomLogger customLogger;
     private boolean inTestMode = false;
+    private int threadPriority = DEFAULT_THREAD_PRIORITY;
 
     private Configuration(){
         //use builder instead
@@ -75,6 +77,10 @@ public class Configuration {
 
     public boolean isInTestMode() {
         return inTestMode;
+    }
+
+    public int getThreadPriority() {
+        return threadPriority;
     }
 
     public static final class Builder {
@@ -201,6 +207,16 @@ public class Configuration {
          */
         public Builder inTestMode() {
             configuration.inTestMode = true;
+            return this;
+        }
+
+        /**
+         * Sets the priority for the threads of this manager. By default it is {@value #DEFAULT_THREAD_PRIORITY}
+         * @param threadPriority
+         * @return
+         */
+        public Builder setThreadPriority(int threadPriority) {
+            configuration.threadPriority = threadPriority;
             return this;
         }
 

--- a/jobqueue/src/main/java/com/path/android/jobqueue/executor/JobConsumerExecutor.java
+++ b/jobqueue/src/main/java/com/path/android/jobqueue/executor/JobConsumerExecutor.java
@@ -1,11 +1,9 @@
 package com.path.android.jobqueue.executor;
 
-import com.path.android.jobqueue.Job;
 import com.path.android.jobqueue.JobHolder;
 import com.path.android.jobqueue.JobManager;
 import com.path.android.jobqueue.JobQueue;
 import com.path.android.jobqueue.TagConstraint;
-import com.path.android.jobqueue.callback.JobManagerCallback;
 import com.path.android.jobqueue.config.Configuration;
 import com.path.android.jobqueue.log.JqLog;
 
@@ -25,6 +23,7 @@ public class JobConsumerExecutor {
     private int maxConsumerSize;
     private int minConsumerSize;
     private int loadFactor;
+    private int threadPriority;
     private final ThreadGroup threadGroup;
     private final Contract contract;
     private final int keepAliveSeconds;
@@ -38,6 +37,7 @@ public class JobConsumerExecutor {
         this.maxConsumerSize = config.getMaxConsumerCount();
         this.minConsumerSize = config.getMinConsumerCount();
         this.keepAliveSeconds = config.getConsumerKeepAlive();
+        this.threadPriority = config.getThreadPriority();
         this.contract = contract;
         threadGroup = new ThreadGroup("JobConsumers");
         runningJobHolders = new ConcurrentHashMap<String, JobHolder>();
@@ -85,6 +85,7 @@ public class JobConsumerExecutor {
         synchronized (threadGroup) {
             Thread thread = new Thread(threadGroup, new JobConsumer(contract, this));
             activeConsumerCount.incrementAndGet();
+            thread.setPriority(threadPriority);
             thread.start();
         }
     }


### PR DESCRIPTION
Hello,

while debugging our app we've found that the threads in jobConsumer are created without setting up a priority. So, if jobManager.addJob() is invoked on main thread they will have the  [Thread.NORM_PRIORITY] (http://developer.android.com/intl/es/reference/java/lang/Thread.html#NORM_PRIORITY), which is the same than the main thread has.

It would be nice to be able to parametrize this. And setup a default thread priority for all the threads created inside the jobManager

Best regards.