### PR TITLE
Resolve a NullPointerException and a SecurityException

### DIFF
--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/MultiThreadTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/MultiThreadTest.java
@@ -38,8 +38,13 @@ public class MultiThreadTest extends JobManagerTestBase {
     @Test
     public void testMultiThreaded() throws Exception {
         multiThreadedJobCounter = new AtomicInteger(0);
+
+        JobManagerTestBase.DummyNetworkUtil dummyNetworkUtil = new JobManagerTestBase.DummyNetworkUtil();
+                dummyNetworkUtil.setNetworkStatus(DummyNetworkUtil.UNMETERED);
+
         final JobManager jobManager = createJobManager(new Configuration.Builder(RuntimeEnvironment.application)
-            .loadFactor(3).maxConsumerCount(10));
+            .networkUtil(dummyNetworkUtil).loadFactor(3).maxConsumerCount(10));
+
         int limit = 200;
         ExecutorService executor = new ThreadPoolExecutor(20, 20, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(limit));
         final String cancelTag = "iWillBeCancelled";

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/PriorityTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/PriorityTest.java
@@ -27,10 +27,14 @@ public class PriorityTest extends JobManagerTestBase {
 
     @Test
     public void testPriority() throws Exception {
+        JobManagerTestBase.DummyNetworkUtil dummyNetworkUtil = new JobManagerTestBase.DummyNetworkUtil();
+        dummyNetworkUtil.setNetworkStatus(DummyNetworkUtil.UNMETERED);
+
         JobManager jobManager = createJobManager(
                 new Configuration.Builder(RuntimeEnvironment.application)
                         .maxConsumerCount(1)
-                        .timer(mockTimer));
+                        .timer(mockTimer)
+                        .networkUtil(dummyNetworkUtil));
         testPriority(jobManager, false);
     }
 

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/RunFailingJobTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/RunFailingJobTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.CoreMatchers.*;
 import com.birbit.android.jobqueue.JobManager;
 import com.birbit.android.jobqueue.Params;
 import com.birbit.android.jobqueue.RetryConstraint;
+import com.birbit.android.jobqueue.config.Configuration;
+import com.birbit.android.jobqueue.network.NetworkUtil;
 
 import org.hamcrest.*;
 import org.junit.Test;
@@ -24,7 +26,15 @@ public class RunFailingJobTest extends JobManagerTestBase {
     @Test
     public void runFailingJob() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        JobManager jobManager = createJobManager();
+
+        JobManagerTestBase.DummyNetworkUtil dummyNetworkUtil = new JobManagerTestBase.DummyNetworkUtil();
+        dummyNetworkUtil.setNetworkStatus(NetworkUtil.UNMETERED);
+
+        JobManager jobManager = createJobManager(
+            new Configuration.Builder(RuntimeEnvironment.application)
+                .timer(mockTimer)
+                .networkUtil(dummyNetworkUtil));
+
         jobManager.addJob(new Job(new Params(0).requireNetwork()) {
             @Override
             public void onAdded() {


### PR DESCRIPTION
1. Add a permission check before attempting to retrieve the network info.
2. Add a check for null when retrieving the ConnectivityManager.