### PR TITLE
Pass last Throwable from onRun() down to onCancel()

### DIFF
--- a/jobqueue/build.gradle
+++ b/jobqueue/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/CallbackManager.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/CallbackManager.java
@@ -1,5 +1,6 @@
 package com.birbit.android.jobqueue;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.birbit.android.jobqueue.callback.JobManagerCallback;
@@ -37,7 +38,7 @@ public class CallbackManager {
         this.factory = factory;
     }
 
-    void addCallback(JobManagerCallback callback) {
+    void addCallback(@NonNull JobManagerCallback callback) {
         callbacks.add(callback);
         callbacksSize.incrementAndGet();
         startIfNeeded();
@@ -49,7 +50,7 @@ public class CallbackManager {
         }
     }
 
-    boolean removeCallback(JobManagerCallback callback) {
+    boolean removeCallback(@NonNull JobManagerCallback callback) {
         boolean removed = callbacks.remove(callback);
         if (removed) {
             callbacksSize.decrementAndGet();
@@ -98,12 +99,12 @@ public class CallbackManager {
         }, "job-manager-callbacks").start();
     }
 
-    private void deliverCancelResult(CancelResultMessage message) {
+    private void deliverCancelResult(@NonNull CancelResultMessage message) {
         message.getCallback().onCancelled(message.getResult());
         startIfNeeded();
     }
 
-    private void deliverMessage(CallbackMessage cm) {
+    private void deliverMessage(@NonNull CallbackMessage cm) {
         switch (cm.getWhat()) {
             case CallbackMessage.ON_ADDED:
                 notifyOnAddedListeners(cm.getJob());
@@ -123,37 +124,37 @@ public class CallbackManager {
         }
     }
 
-    private void notifyOnCancelListeners(Job job, boolean byCancelRequest, @Nullable Throwable throwable) {
+    private void notifyOnCancelListeners(@NonNull Job job, boolean byCancelRequest, @Nullable Throwable throwable) {
         for (JobManagerCallback callback : callbacks) {
             callback.onJobCancelled(job, byCancelRequest, throwable);
         }
     }
 
-    private void notifyOnRunListeners(Job job, int resultCode) {
+    private void notifyOnRunListeners(@NonNull Job job, int resultCode) {
         for (JobManagerCallback callback : callbacks) {
             callback.onJobRun(job, resultCode);
         }
     }
 
-    private void notifyAfterRunListeners(Job job, int resultCode) {
+    private void notifyAfterRunListeners(@NonNull Job job, int resultCode) {
         for (JobManagerCallback callback : callbacks) {
             callback.onAfterJobRun(job, resultCode);
         }
     }
 
-    private void notifyOnDoneListeners(Job job) {
+    private void notifyOnDoneListeners(@NonNull Job job) {
         for (JobManagerCallback callback : callbacks) {
             callback.onDone(job);
         }
     }
 
-    private void notifyOnAddedListeners(Job job) {
+    private void notifyOnAddedListeners(@NonNull Job job) {
         for (JobManagerCallback callback : callbacks) {
             callback.onJobAdded(job);
         }
     }
 
-    public void notifyOnRun(Job job, int result) {
+    public void notifyOnRun(@NonNull Job job, int result) {
         if (!hasAnyCallbacks()) {
             return;
         }
@@ -166,7 +167,7 @@ public class CallbackManager {
         return callbacksSize.get() > 0;
     }
 
-    public void notifyAfterRun(Job job, int result) {
+    public void notifyAfterRun(@NonNull Job job, int result) {
         if (!hasAnyCallbacks()) {
             return;
         }
@@ -175,7 +176,7 @@ public class CallbackManager {
         messageQueue.post(callback);
     }
 
-    public void notifyOnCancel(Job job, boolean byCancelRequest, @Nullable Throwable throwable) {
+    public void notifyOnCancel(@NonNull Job job, boolean byCancelRequest, @Nullable Throwable throwable) {
         if (!hasAnyCallbacks()) {
             return;
         }
@@ -184,7 +185,7 @@ public class CallbackManager {
         messageQueue.post(callback);
     }
 
-    public void notifyOnAdded(Job job) {
+    public void notifyOnAdded(@NonNull Job job) {
         if (!hasAnyCallbacks()) {
             return;
         }
@@ -193,7 +194,7 @@ public class CallbackManager {
         messageQueue.post(callback);
     }
 
-    public void notifyOnDone(Job job) {
+    public void notifyOnDone(@NonNull Job job) {
         if (!hasAnyCallbacks()) {
             return;
         }
@@ -202,7 +203,7 @@ public class CallbackManager {
         messageQueue.post(callback);
     }
 
-    public void notifyCancelResult(CancelResult result, CancelResult.AsyncCancelCallback callback) {
+    public void notifyCancelResult(@NonNull CancelResult result, @NonNull CancelResult.AsyncCancelCallback callback) {
         CancelResultMessage message = factory.obtain(CancelResultMessage.class);
         message.set(callback, result);
         messageQueue.post(message);

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/CallbackManager.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/CallbackManager.java
@@ -1,5 +1,8 @@
 package com.birbit.android.jobqueue;
 
+import android.support.annotation.Nullable;
+
+import com.birbit.android.jobqueue.callback.JobManagerCallback;
 import com.birbit.android.jobqueue.messaging.Message;
 import com.birbit.android.jobqueue.messaging.MessageFactory;
 import com.birbit.android.jobqueue.messaging.MessageQueueConsumer;
@@ -9,9 +12,6 @@ import com.birbit.android.jobqueue.messaging.message.CallbackMessage;
 import com.birbit.android.jobqueue.messaging.message.CancelResultMessage;
 import com.birbit.android.jobqueue.messaging.message.CommandMessage;
 import com.birbit.android.jobqueue.messaging.message.PublicQueryMessage;
-import com.birbit.android.jobqueue.CancelResult;
-import com.birbit.android.jobqueue.Job;
-import com.birbit.android.jobqueue.callback.JobManagerCallback;
 import com.birbit.android.jobqueue.timer.Timer;
 
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -112,7 +112,7 @@ public class CallbackManager {
                 notifyAfterRunListeners(cm.getJob(), cm.getResultCode());
                 break;
             case CallbackMessage.ON_CANCEL:
-                notifyOnCancelListeners(cm.getJob(), cm.isByUserRequest());
+                notifyOnCancelListeners(cm.getJob(), cm.isByUserRequest(), cm.getThrowable());
                 break;
             case CallbackMessage.ON_DONE:
                 notifyOnDoneListeners(cm.getJob());
@@ -123,9 +123,9 @@ public class CallbackManager {
         }
     }
 
-    private void notifyOnCancelListeners(Job job, boolean byCancelRequest) {
+    private void notifyOnCancelListeners(Job job, boolean byCancelRequest, @Nullable Throwable throwable) {
         for (JobManagerCallback callback : callbacks) {
-            callback.onJobCancelled(job, byCancelRequest);
+            callback.onJobCancelled(job, byCancelRequest, throwable);
         }
     }
 
@@ -175,12 +175,12 @@ public class CallbackManager {
         messageQueue.post(callback);
     }
 
-    public void notifyOnCancel(Job job, boolean byCancelRequest) {
+    public void notifyOnCancel(Job job, boolean byCancelRequest, @Nullable Throwable throwable) {
         if (!hasAnyCallbacks()) {
             return;
         }
         CallbackMessage callback = factory.obtain(CallbackMessage.class);
-        callback.set(job, CallbackMessage.ON_CANCEL, byCancelRequest);
+        callback.set(job, CallbackMessage.ON_CANCEL, byCancelRequest, throwable);
         messageQueue.post(callback);
     }
 

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/CancelHandler.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/CancelHandler.java
@@ -1,10 +1,5 @@
 package com.birbit.android.jobqueue;
 
-import com.birbit.android.jobqueue.CancelReason;
-import com.birbit.android.jobqueue.CancelResult;
-import com.birbit.android.jobqueue.Job;
-import com.birbit.android.jobqueue.JobHolder;
-import com.birbit.android.jobqueue.TagConstraint;
 import com.birbit.android.jobqueue.log.JqLog;
 
 import java.util.ArrayList;
@@ -79,7 +74,7 @@ class CancelHandler {
             jobManagerThread.callbackManager.notifyCancelResult(result, callback);
         }
         for (JobHolder jobHolder : cancelled) {
-            jobManagerThread.callbackManager.notifyOnCancel(jobHolder.getJob(), true);
+            jobManagerThread.callbackManager.notifyOnCancel(jobHolder.getJob(), true, jobHolder.getThrowable());
         }
     }
 

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/CancelReason.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/CancelReason.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * A list of possible reasons why a Job was cancelled. A reason will be passed to {@link Job#onCancel(int)}.
+ * A list of possible reasons why a Job was cancelled. A reason will be passed to {@link Job#onCancel(int, Throwable)}.
  */
 @Retention(RetentionPolicy.SOURCE)
 @IntDef({CancelReason.REACHED_RETRY_LIMIT,

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/JobHolder.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/JobHolder.java
@@ -254,7 +254,7 @@ public class JobHolder {
     }
 
     public void onCancel(@CancelReason int cancelReason) {
-        job.onCancel(cancelReason, getThrowable());
+        job.onCancel(cancelReason, throwable);
     }
 
     public RetryConstraint getRetryConstraint() {

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/JobHolder.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/JobHolder.java
@@ -1,8 +1,9 @@
 package com.birbit.android.jobqueue;
 
-import com.birbit.android.jobqueue.config.Configuration;
-
 import android.content.Context;
+import android.support.annotation.Nullable;
+
+import com.birbit.android.jobqueue.config.Configuration;
 
 import java.util.Collections;
 import java.util.Set;
@@ -64,6 +65,10 @@ public class JobHolder {
     private boolean cancelled;
     private boolean cancelledSingleId;
     private boolean successful;
+    /**
+     * Eventual exception thrown from the last execution of {@link Job#onRun}
+     */
+    @Nullable private Throwable throwable;
 
     /**
      * @param priority         Higher is better
@@ -249,11 +254,20 @@ public class JobHolder {
     }
 
     public void onCancel(@CancelReason int cancelReason) {
-        job.onCancel(cancelReason);
+        job.onCancel(cancelReason, getThrowable());
     }
 
     public RetryConstraint getRetryConstraint() {
         return job.retryConstraint;
+    }
+
+    void setThrowable(@Nullable Throwable throwable) {
+        this.throwable = throwable;
+    }
+
+    @Nullable
+    Throwable getThrowable() {
+        return throwable;
     }
 
     public static class Builder {

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/JobManager.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/JobManager.java
@@ -1,5 +1,12 @@
 package com.birbit.android.jobqueue;
 
+import android.os.Looper;
+import android.support.annotation.NonNull;
+
+import com.birbit.android.jobqueue.callback.JobManagerCallback;
+import com.birbit.android.jobqueue.callback.JobManagerCallbackAdapter;
+import com.birbit.android.jobqueue.config.Configuration;
+import com.birbit.android.jobqueue.log.JqLog;
 import com.birbit.android.jobqueue.messaging.Message;
 import com.birbit.android.jobqueue.messaging.MessageFactory;
 import com.birbit.android.jobqueue.messaging.MessageQueue;
@@ -11,18 +18,6 @@ import com.birbit.android.jobqueue.messaging.message.PublicQueryMessage;
 import com.birbit.android.jobqueue.messaging.message.SchedulerMessage;
 import com.birbit.android.jobqueue.scheduling.Scheduler;
 import com.birbit.android.jobqueue.scheduling.SchedulerConstraint;
-import com.birbit.android.jobqueue.AsyncAddCallback;
-import com.birbit.android.jobqueue.CancelResult;
-import com.birbit.android.jobqueue.Job;
-import com.birbit.android.jobqueue.JobStatus;
-import com.birbit.android.jobqueue.TagConstraint;
-import com.birbit.android.jobqueue.callback.JobManagerCallback;
-import com.birbit.android.jobqueue.callback.JobManagerCallbackAdapter;
-import com.birbit.android.jobqueue.config.Configuration;
-import com.birbit.android.jobqueue.log.JqLog;
-
-import android.os.Looper;
-import android.support.annotation.NonNull;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -277,7 +272,7 @@ public class JobManager {
         final String uuid = job.getId();
         addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onJobAdded(Job job) {
+            public void onJobAdded(@NonNull Job job) {
                 if (uuid.equals(job.getId())) {
                     latch.countDown();
                     removeCallback(this);
@@ -307,7 +302,7 @@ public class JobManager {
         final String uuid = job.getId();
         addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onJobAdded(Job job) {
+            public void onJobAdded(@NonNull Job job) {
                 if (uuid.equals(job.getId())) {
                     try {
                         callback.onAdded();

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/JobManagerThread.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/JobManagerThread.java
@@ -3,6 +3,10 @@ package com.birbit.android.jobqueue;
 import android.content.Context;
 import android.support.annotation.Nullable;
 
+import com.birbit.android.jobqueue.callback.JobManagerCallback;
+import com.birbit.android.jobqueue.config.Configuration;
+import com.birbit.android.jobqueue.di.DependencyInjector;
+import com.birbit.android.jobqueue.log.JqLog;
 import com.birbit.android.jobqueue.messaging.Message;
 import com.birbit.android.jobqueue.messaging.MessageFactory;
 import com.birbit.android.jobqueue.messaging.MessageQueueConsumer;
@@ -11,25 +15,21 @@ import com.birbit.android.jobqueue.messaging.message.AddJobMessage;
 import com.birbit.android.jobqueue.messaging.message.CancelMessage;
 import com.birbit.android.jobqueue.messaging.message.CommandMessage;
 import com.birbit.android.jobqueue.messaging.message.ConstraintChangeMessage;
-import com.birbit.android.jobqueue.messaging.message.PublicQueryMessage;
 import com.birbit.android.jobqueue.messaging.message.JobConsumerIdleMessage;
+import com.birbit.android.jobqueue.messaging.message.PublicQueryMessage;
 import com.birbit.android.jobqueue.messaging.message.RunJobResultMessage;
 import com.birbit.android.jobqueue.messaging.message.SchedulerMessage;
-import com.birbit.android.jobqueue.scheduling.Scheduler;
-import com.birbit.android.jobqueue.scheduling.SchedulerConstraint;
-import com.birbit.android.jobqueue.callback.JobManagerCallback;
-import com.birbit.android.jobqueue.config.Configuration;
-import com.birbit.android.jobqueue.di.DependencyInjector;
-import com.birbit.android.jobqueue.log.JqLog;
 import com.birbit.android.jobqueue.network.NetworkEventProvider;
 import com.birbit.android.jobqueue.network.NetworkUtil;
+import com.birbit.android.jobqueue.scheduling.Scheduler;
+import com.birbit.android.jobqueue.scheduling.SchedulerConstraint;
 import com.birbit.android.jobqueue.timer.Timer;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.birbit.android.jobqueue.network.NetworkUtil.DISCONNECTED;
 import static com.birbit.android.jobqueue.network.NetworkUtil.UNMETERED;
@@ -501,7 +501,7 @@ class JobManagerThread implements Runnable, NetworkEventProvider.Listener {
         } catch (Throwable t) {
             JqLog.e(t, "job's onCancel did throw an exception, ignoring...");
         }
-        callbackManager.notifyOnCancel(jobHolder.getJob(), false);
+        callbackManager.notifyOnCancel(jobHolder.getJob(), false, jobHolder.getThrowable());
     }
 
     private void insertOrReplace(JobHolder jobHolder) {

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/callback/JobManagerCallback.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/callback/JobManagerCallback.java
@@ -1,5 +1,8 @@
 package com.birbit.android.jobqueue.callback;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.CancelResult;
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.JobHolder;
@@ -57,7 +60,7 @@ public interface JobManagerCallback {
      *
      * @param job The Job that was added to the JobManager.
      */
-    void onJobAdded(Job job);
+    void onJobAdded(@NonNull Job job);
 
     /**
      * Called after a Job has been Run. Might be called multiple times if the Job runs multiple
@@ -74,7 +77,7 @@ public interface JobManagerCallback {
      *                   <li>{@link #RESULT_FAIL_WILL_RETRY}</li>
      *                   </ul>
      */
-    void onJobRun(Job job, int resultCode);
+    void onJobRun(@NonNull Job job, int resultCode);
 
     /**
      * Called when a job is cancelled.
@@ -82,8 +85,9 @@ public interface JobManagerCallback {
      * @param job              The Job that was cancelled.
      * @param byCancelRequest  If true, the Job was cancelled in response to a
      *                         {@link com.birbit.android.jobqueue.JobManager#cancelJobs(TagConstraint, String...)} request.
+     * @param throwable        The exception that was thrown from the last execution of {@link Job#onRun()}
      */
-    void onJobCancelled(Job job, boolean byCancelRequest);
+    void onJobCancelled(@NonNull Job job, boolean byCancelRequest, @Nullable Throwable throwable);
 
     /**
      * Called <b>after</b> a Job is removed from the JobManager. It might be cancelled or onFinished.
@@ -91,7 +95,7 @@ public interface JobManagerCallback {
      *
      * @param job The Job that was just removed from the JobManager.
      */
-    void onDone(Job job);
+    void onDone(@NonNull Job job);
 
     /**
      * Called <b>after</b> a Job is run and its run result has been handled. For instance, if the
@@ -102,5 +106,5 @@ public interface JobManagerCallback {
      *
      * @see #onJobRun(Job, int)
      */
-    void onAfterJobRun(Job job, int resultCode);
+    void onAfterJobRun(@NonNull Job job, int resultCode);
 }

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/callback/JobManagerCallbackAdapter.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/callback/JobManagerCallbackAdapter.java
@@ -1,5 +1,8 @@
 package com.birbit.android.jobqueue.callback;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.Job;
 
 /**
@@ -8,27 +11,27 @@ import com.birbit.android.jobqueue.Job;
  */
 public class JobManagerCallbackAdapter implements JobManagerCallback {
     @Override
-    public void onJobAdded(Job job) {
+    public void onJobAdded(@NonNull Job job) {
 
     }
 
     @Override
-    public void onJobRun(Job job, int resultCode) {
+    public void onJobRun(@NonNull Job job, int resultCode) {
 
     }
 
     @Override
-    public void onJobCancelled(Job job, boolean byCancelRequest) {
+    public void onJobCancelled(@NonNull Job job, boolean byCancelRequest, @Nullable Throwable throwable) {
 
     }
 
     @Override
-    public void onDone(Job job) {
+    public void onDone(@NonNull Job job) {
 
     }
 
     @Override
-    public void onAfterJobRun(Job job, int resultCode) {
+    public void onAfterJobRun(@NonNull Job job, int resultCode) {
 
     }
 }

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/messaging/message/CallbackMessage.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/messaging/message/CallbackMessage.java
@@ -1,8 +1,10 @@
 package com.birbit.android.jobqueue.messaging.message;
 
+import android.support.annotation.Nullable;
+
+import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.messaging.Message;
 import com.birbit.android.jobqueue.messaging.Type;
-import com.birbit.android.jobqueue.Job;
 
 /**
  * Used for external callbacks to user code
@@ -18,6 +20,8 @@ public class CallbackMessage extends Message {
     private int resultCode;
     private boolean byUserRequest;
     private Job job;
+    @Nullable private Throwable throwable;
+
     public CallbackMessage() {
         super(Type.CALLBACK);
     }
@@ -25,6 +29,7 @@ public class CallbackMessage extends Message {
     @Override
     protected void onRecycled() {
         job = null;
+        throwable = null;
     }
 
     public void set(Job job, int what) {
@@ -38,10 +43,11 @@ public class CallbackMessage extends Message {
         this.job = job;
     }
 
-    public void set(Job job, int what, boolean byUserRequest) {
+    public void set(Job job, int what, boolean byUserRequest, @Nullable Throwable throwable) {
         this.what = what;
         this.byUserRequest = byUserRequest;
         this.job = job;
+        this.throwable = throwable;
     }
 
     public int getWhat() {
@@ -58,5 +64,10 @@ public class CallbackMessage extends Message {
 
     public Job getJob() {
         return job;
+    }
+
+    @Nullable
+    public Throwable getThrowable() {
+        return throwable;
     }
 }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/ApplicationContextTests.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/ApplicationContextTests.java
@@ -1,5 +1,9 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.CancelReason;
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.JobManager;
@@ -14,13 +18,11 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import android.content.Context;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = com.birbit.android.jobqueue.BuildConfig.class)
@@ -93,12 +95,12 @@ public class ApplicationContextTests extends JobManagerTestBase {
         }
 
         @Override
-        protected void onCancel(@CancelReason int cancelReason) {
+        protected void onCancel(@CancelReason int cancelReason, @Nullable Throwable throwable) {
             assertContext("onCancel");
         }
 
         @Override
-        protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+        protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
             assertContext("shouldReRunOnThrowable");
             return retryCount < 2 ? RetryConstraint.RETRY : RetryConstraint.CANCEL;
         }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/CountTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/CountTest.java
@@ -15,6 +15,7 @@ import org.robolectric.annotation.Config;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -37,7 +38,7 @@ public class CountTest extends JobManagerTestBase {
         final CountDownLatch jobsToRun = new CountDownLatch(20);
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onAfterJobRun(Job job, int resultCode) {
+            public void onAfterJobRun(@NonNull Job job, int resultCode) {
                 if (resultCode == JobManagerCallback.RESULT_SUCCEED) {
                     jobsToRun.countDown();
                 }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/DelayedRunTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/DelayedRunTest.java
@@ -1,5 +1,7 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.support.annotation.NonNull;
+
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.JobManager;
 import com.birbit.android.jobqueue.Params;
@@ -77,18 +79,18 @@ public class DelayedRunTest extends JobManagerTestBase {
         final JobManager jobManager = createJobManager();
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onJobRun(Job job, int resultCode) {
+            public void onJobRun(@NonNull Job job, int resultCode) {
                 super.onJobRun(job, resultCode);
                 System.out.println("CB job run " + job.getTags().toArray()[0] + ", " + mockTimer.nanoTime());
             }
 
             @Override
-            public void onDone(Job job) {
+            public void onDone(@NonNull Job job) {
                 System.out.println("CB job done " + job.getTags().toArray()[0] + ", " + mockTimer.nanoTime());
             }
 
             @Override
-            public void onAfterJobRun(Job job, int resultCode) {
+            public void onAfterJobRun(@NonNull Job job, int resultCode) {
                 System.out.println("CB job after run " + job.getTags().toArray()[0] + ", " + mockTimer.nanoTime());
             }
         });

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/GroupingTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/GroupingTest.java
@@ -18,6 +18,7 @@ import org.robolectric.annotation.Config;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -75,7 +76,7 @@ public class GroupingTest extends JobManagerTestBase {
         final CountDownLatch aJobRun = new CountDownLatch(1);
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onJobRun(Job job, int resultCode) {
+            public void onJobRun(@NonNull Job job, int resultCode) {
                 aJobRun.countDown();
             }
         });

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/JobManagerTestBase.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/JobManagerTestBase.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import com.birbit.android.jobqueue.JobManager;
 import com.birbit.android.jobqueue.JobManagerThreadRunnable;
@@ -169,7 +170,7 @@ public class JobManagerTestBase extends TestBase {
         }
 
         @Override
-        protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+        protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
             return RetryConstraint.RETRY;
         }
 
@@ -279,7 +280,7 @@ public class JobManagerTestBase extends TestBase {
         final CountDownLatch latch = new CountDownLatch(uuids.size());
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onDone(Job job) {
+            public void onDone(@NonNull Job job) {
                 if (uuids.remove(job.getId())) {
                     latch.countDown();
                 }
@@ -297,7 +298,7 @@ public class JobManagerTestBase extends TestBase {
         final Throwable[] throwable = new Throwable[1];
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onDone(Job job) {
+            public void onDone(@NonNull Job job) {
                 synchronized (this) {
                     super.onDone(job);
                     if (callback != null) {

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/JobStatusTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/JobStatusTest.java
@@ -18,6 +18,7 @@ import org.robolectric.annotation.Config;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -84,7 +85,7 @@ public class JobStatusTest extends JobManagerTestBase {
         final CountDownLatch twoLatchJobDone = new CountDownLatch(1);
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onAfterJobRun(Job job, int resultCode) {
+            public void onAfterJobRun(@NonNull Job job, int resultCode) {
                 if (job == twoLatchJob && resultCode == RESULT_SUCCEED) {
                     jobManager.removeCallback(this);
                     twoLatchJobDone.countDown();
@@ -115,7 +116,7 @@ public class JobStatusTest extends JobManagerTestBase {
         final CountDownLatch networkRequiredLatch = new CountDownLatch(networkRequiringJobIndices.size());
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onDone(Job job) {
+            public void onDone(@NonNull Job job) {
                 if (job.getTags().contains(REQ_NETWORK_TAG)) {
                     networkRequiredLatch.countDown();
                 }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/KeepAliveTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/KeepAliveTest.java
@@ -17,6 +17,7 @@ import org.robolectric.annotation.Config;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -43,7 +44,7 @@ public class KeepAliveTest extends JobManagerTestBase {
         final CountDownLatch jobDone = new CountDownLatch(1);
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onDone(Job job) {
+            public void onDone(@NonNull Job job) {
                 jobDone.countDown();
             }
         });

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/MultiThreadTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/MultiThreadTest.java
@@ -1,5 +1,6 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.birbit.android.jobqueue.CancelResult;
@@ -115,7 +116,7 @@ public class MultiThreadTest extends JobManagerTestBase {
         }
 
         @Override
-        protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+        protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
             return RetryConstraint.RETRY;
         }
     };

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/NetworkJobTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/NetworkJobTest.java
@@ -1,5 +1,10 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.CancelReason;
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.JobManager;
@@ -10,21 +15,22 @@ import com.birbit.android.jobqueue.callback.JobManagerCallbackAdapter;
 import com.birbit.android.jobqueue.config.Configuration;
 import com.birbit.android.jobqueue.network.NetworkUtil;
 import com.birbit.android.jobqueue.test.jobs.DummyJob;
-import static org.hamcrest.CoreMatchers.*;
-import org.hamcrest.*;
+
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.*;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-
-import android.annotation.TargetApi;
-import android.os.Build;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
 @Config(constants = com.birbit.android.jobqueue.BuildConfig.class)
@@ -134,7 +140,7 @@ public class NetworkJobTest extends JobManagerTestBase {
         final CountDownLatch noNetworkLatch = new CountDownLatch(2);
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onAfterJobRun(Job job, int resultCode) {
+            public void onAfterJobRun(@NonNull Job job, int resultCode) {
                 if (resultCode == JobManagerCallback.RESULT_SUCCEED) {
                     MatcherAssert.assertThat("should be a no network job", job.requiresNetwork(mockTimer), is(false));
                     noNetworkLatch.countDown();
@@ -150,7 +156,7 @@ public class NetworkJobTest extends JobManagerTestBase {
         final CountDownLatch networkLatch = new CountDownLatch(2);
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onAfterJobRun(Job job, int resultCode) {
+            public void onAfterJobRun(@NonNull Job job, int resultCode) {
                 if (resultCode == JobManagerCallback.RESULT_SUCCEED) {
                     MatcherAssert.assertThat("should be a network job", job.requiresNetwork(mockTimer), is(true));
                     networkLatch.countDown();
@@ -190,12 +196,12 @@ public class NetworkJobTest extends JobManagerTestBase {
         }
 
         @Override
-        protected void onCancel(@CancelReason int cancelReason) {
+        protected void onCancel(@CancelReason int cancelReason, @Nullable Throwable throwable) {
 
         }
 
         @Override
-        protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+        protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
             throw new RuntimeException("not expected arrive here");
         }
     }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/PriorityTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/PriorityTest.java
@@ -1,24 +1,30 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.CancelReason;
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.JobManager;
 import com.birbit.android.jobqueue.Params;
 import com.birbit.android.jobqueue.RetryConstraint;
 import com.birbit.android.jobqueue.config.Configuration;
-import static org.hamcrest.CoreMatchers.*;
-import org.hamcrest.*;
+
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.*;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-
-import android.annotation.TargetApi;
-import android.os.Build;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = com.birbit.android.jobqueue.BuildConfig.class)
@@ -70,12 +76,12 @@ public class PriorityTest extends JobManagerTestBase {
         }
 
         @Override
-        protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+        protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
             return RetryConstraint.CANCEL;
         }
 
         @Override
-        protected void onCancel(@CancelReason int cancelReason) {
+        protected void onCancel(@CancelReason int cancelReason, @Nullable Throwable throwable) {
 
         }
     }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/RetryLogicTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/RetryLogicTest.java
@@ -1,5 +1,11 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Pair;
+
 import com.birbit.android.jobqueue.CancelReason;
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.JobManager;
@@ -16,13 +22,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
-import android.annotation.TargetApi;
-import android.os.Build;
-import android.util.Pair;
-
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.CoreMatchers.*;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,6 +31,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = com.birbit.android.jobqueue.BuildConfig.class)
@@ -192,7 +195,7 @@ public class RetryLogicTest extends JobManagerTestBase {
         final Throwable[] afterJobError = new Throwable[1];
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onJobRun(Job job, int resultCode) {
+            public void onJobRun(@NonNull Job job, int resultCode) {
                 synchronized (this) {
                     try {
                         if (job instanceof RetryJob) {
@@ -209,7 +212,7 @@ public class RetryLogicTest extends JobManagerTestBase {
             }
 
             @Override
-            public void onAfterJobRun(Job job, int resultCode) {
+            public void onAfterJobRun(@NonNull Job job, int resultCode) {
                 synchronized (this) {
                     try {
                         if (job instanceof RetryJob) {
@@ -305,7 +308,7 @@ public class RetryLogicTest extends JobManagerTestBase {
         final JobManager jobManager = createJobManager();
         jobManager.addCallback(new JobManagerCallbackAdapter() {
             @Override
-            public void onAfterJobRun(Job job, int resultCode) {
+            public void onAfterJobRun(@NonNull Job job, int resultCode) {
                 try {
                     mockTimer.incrementMs(1999);
                     assertThat("no jobs should be ready", jobManager.countReadyJobs(), is(0));
@@ -526,7 +529,7 @@ public class RetryLogicTest extends JobManagerTestBase {
         }
 
         @Override
-        protected void onCancel(@CancelReason int cancelReason) {
+        protected void onCancel(@CancelReason int cancelReason, @Nullable Throwable throwable) {
             if (onCancelCallback != null) {
                 onCancelCallback.on(this);
             }
@@ -534,8 +537,8 @@ public class RetryLogicTest extends JobManagerTestBase {
         }
 
         @Override
-        protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount,
-                int maxRunCount) {
+        protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount,
+                                                         int maxRunCount) {
             if (retryProvider != null) {
                 return retryProvider.build(this, throwable, runCount, maxRunCount);
             }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/RunFailingJobTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/RunFailingJobTest.java
@@ -1,22 +1,24 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.CancelReason;
 import com.birbit.android.jobqueue.Job;
-
-import static org.hamcrest.CoreMatchers.*;
-
 import com.birbit.android.jobqueue.JobManager;
 import com.birbit.android.jobqueue.Params;
 import com.birbit.android.jobqueue.RetryConstraint;
 
-import org.hamcrest.*;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.*;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = com.birbit.android.jobqueue.BuildConfig.class)
@@ -37,12 +39,12 @@ public class RunFailingJobTest extends JobManagerTestBase {
             }
 
             @Override
-            protected void onCancel(@CancelReason int cancelReason) {
+            protected void onCancel(@CancelReason int cancelReason, @Nullable Throwable throwable) {
                 latch.countDown();
             }
 
             @Override
-            protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+            protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
                 return RetryConstraint.CANCEL;
             }
         });

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/SchedulerSimpleTestCase.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/SchedulerSimpleTestCase.java
@@ -1,15 +1,17 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.CancelReason;
-import com.birbit.android.jobqueue.CancelResult;
-import com.birbit.android.jobqueue.JobManager;
-import com.birbit.android.jobqueue.RetryConstraint;
-import com.birbit.android.jobqueue.scheduling.Scheduler;
-import com.birbit.android.jobqueue.scheduling.SchedulerConstraint;
 import com.birbit.android.jobqueue.Job;
+import com.birbit.android.jobqueue.JobManager;
 import com.birbit.android.jobqueue.Params;
+import com.birbit.android.jobqueue.RetryConstraint;
 import com.birbit.android.jobqueue.config.Configuration;
 import com.birbit.android.jobqueue.network.NetworkUtil;
+import com.birbit.android.jobqueue.scheduling.Scheduler;
+import com.birbit.android.jobqueue.scheduling.SchedulerConstraint;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -124,12 +126,12 @@ public class SchedulerSimpleTestCase extends JobManagerTestBase {
         }
 
         @Override
-        protected void onCancel(@CancelReason int cancelReason) {
+        protected void onCancel(@CancelReason int cancelReason, @Nullable Throwable throwable) {
 
         }
 
         @Override
-        protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+        protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
             throw new UnsupportedOperationException("not expected to arrive here");
         }
     }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/SlowOnAddedTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/SlowOnAddedTest.java
@@ -1,19 +1,24 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.CancelReason;
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.JobManager;
 import com.birbit.android.jobqueue.Params;
 import com.birbit.android.jobqueue.RetryConstraint;
 import com.birbit.android.jobqueue.test.jobs.DummyJob;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.*;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.concurrent.CountDownLatch;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = com.birbit.android.jobqueue.BuildConfig.class)
@@ -71,12 +76,12 @@ public class SlowOnAddedTest extends JobManagerTestBase {
         }
 
         @Override
-        protected void onCancel(@CancelReason int cancelReason) {
+        protected void onCancel(@CancelReason int cancelReason, @Nullable Throwable throwable) {
 
         }
 
         @Override
-        protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+        protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
             return RetryConstraint.RETRY;
         }
     }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobs/DummyJob.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobs/DummyJob.java
@@ -1,5 +1,8 @@
 package com.birbit.android.jobqueue.test.jobs;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.birbit.android.jobqueue.CancelReason;
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.Params;
@@ -26,12 +29,12 @@ public class DummyJob extends Job {
     }
 
     @Override
-    protected void onCancel(@CancelReason int cancelReason) {
+    protected void onCancel(@CancelReason int cancelReason, @Nullable Throwable throwable) {
         onCancelCnt++;
     }
 
     @Override
-    protected RetryConstraint shouldReRunOnThrowable(Throwable throwable, int runCount, int maxRunCount) {
+    protected RetryConstraint shouldReRunOnThrowable(@NonNull Throwable throwable, int runCount, int maxRunCount) {
         shouldReRunOnThrowableCnt++;
         return RetryConstraint.CANCEL;
     }


### PR DESCRIPTION
Right now if `onRun()` throws a `Throwable` only `shouldReRunOnThrowable()` is able to read it, but often you wanna be able to know why a `Job` failed also in the `onCancel()` method.

This PR allows `onCancel()` to receive the most recent `Throwable` thrown by `onRun()`. This also extends to `JobManagerCallback`.