### PR TITLE
fix flaky retry test

### DIFF
--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/messaging/message/CommandMessage.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/messaging/message/CommandMessage.java
@@ -6,7 +6,10 @@ import com.birbit.android.jobqueue.messaging.Type;
 public class CommandMessage extends Message {
     public static final int QUIT = 1;
     public static final int POKE = 2; // simple message to wake it up
+    public static final int RUNNABLE = 3; // only used in tests
     private int what;
+
+    private Runnable runnable;
 
     public CommandMessage() {
         super(Type.COMMAND);
@@ -15,6 +18,7 @@ public class CommandMessage extends Message {
     @Override
     protected void onRecycled() {
         what = -1;
+        runnable = null;
     }
 
     public int getWhat() {
@@ -23,6 +27,14 @@ public class CommandMessage extends Message {
 
     public void set(int what) {
         this.what = what;
+    }
+
+    public Runnable getRunnable() {
+        return runnable;
+    }
+
+    public void setRunnable(Runnable runnable) {
+        this.runnable = runnable;
     }
 
     @Override

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/JobManagerTrojan.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/JobManagerTrojan.java
@@ -1,0 +1,14 @@
+package com.birbit.android.jobqueue;
+
+/**
+ * Proxy class to access package locals
+ */
+public class JobManagerTrojan {
+    public static ConsumerManager getConsumerManager(JobManager jobManager) {
+        return jobManager.jobManagerThread.consumerManager;
+    }
+
+    public static CallbackManager getCallbackManager(JobManager jobManager) {
+        return jobManager.jobManagerThread.callbackManager;
+    }
+}


### PR DESCRIPTION
This CL fixes a bug in retry test where it could hit a race condition
and report false negatives if next job starts before callbacks
are consumed