### PR TITLE
avoid infinite loop in idle callbacks

### DIFF
--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/JobManagerThread.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/JobManagerThread.java
@@ -222,6 +222,7 @@ class JobManagerThread implements Runnable, NetworkEventProvider.Listener {
         messageQueue.consume(new MessageQueueConsumer() {
             @Override
             public void handleMessage(Message message) {
+                canScheduleConstraintChangeOnIdle = true;
                 switch (message.type) {
                     case ADD_JOB:
                         handleAddJob((AddJobMessage) message);

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/JobManagerThread.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/JobManagerThread.java
@@ -61,6 +61,8 @@ class JobManagerThread implements Runnable, NetworkEventProvider.Listener {
      * for simplicity.
      */
     private boolean shouldCancelAllScheduledWhenEmpty = false;
+    // see https://github.com/yigit/android-priority-jobqueue/issues/262
+    private boolean canScheduleConstraintChangeOnIdle = true;
 
     final PriorityMessageQueue messageQueue;
     @Nullable
@@ -234,7 +236,11 @@ class JobManagerThread implements Runnable, NetworkEventProvider.Listener {
                         handleRunJobResult((RunJobResultMessage) message);
                         break;
                     case CONSTRAINT_CHANGE:
-                        consumerManager.handleConstraintChange();
+                        boolean handled = consumerManager.handleConstraintChange();
+                        ConstraintChangeMessage constraintChangeMessage =
+                                (ConstraintChangeMessage) message;
+                        canScheduleConstraintChangeOnIdle = handled ||
+                                !constraintChangeMessage.isForNextJob();
                         break;
                     case CANCEL:
                         handleCancel((CancelMessage) message);
@@ -253,8 +259,13 @@ class JobManagerThread implements Runnable, NetworkEventProvider.Listener {
 
             @Override
             public void onIdle() {
-                JqLog.d("joq idle. running:? %s", running);
+                JqLog.v("joq idle. running:? %s", running);
                 if (!running) {
+                    return;
+                }
+                if (!canScheduleConstraintChangeOnIdle) {
+                    JqLog.v("skipping scheduling a new idle callback because looks like last one"
+                            + " did not do anything");
                     return;
                 }
                 Long nextJobTimeNs = getNextWakeUpNs(true);
@@ -264,6 +275,7 @@ class JobManagerThread implements Runnable, NetworkEventProvider.Listener {
                 if (nextJobTimeNs != null) {
                     ConstraintChangeMessage constraintMessage =
                             messageFactory.obtain(ConstraintChangeMessage.class);
+                    constraintMessage.setForNextJob(true);
                     messageQueue.postAt(constraintMessage, nextJobTimeNs);
                 } else if (scheduler != null) {
                     // if we have a scheduler but the queue is empty, just clean them all.

--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/messaging/message/ConstraintChangeMessage.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/messaging/message/ConstraintChangeMessage.java
@@ -4,12 +4,21 @@ import com.birbit.android.jobqueue.messaging.Message;
 import com.birbit.android.jobqueue.messaging.Type;
 
 public class ConstraintChangeMessage extends Message {
+    private boolean forNextJob;
     public ConstraintChangeMessage() {
         super(Type.CONSTRAINT_CHANGE);
     }
 
     @Override
     protected void onRecycled() {
+        forNextJob = false;
+    }
 
+    public boolean isForNextJob() {
+        return forNextJob;
+    }
+
+    public void setForNextJob(boolean forNextJob) {
+        this.forNextJob = forNextJob;
     }
 }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/LoadFactorTest.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobmanager/LoadFactorTest.java
@@ -1,12 +1,25 @@
 package com.birbit.android.jobqueue.test.jobmanager;
 
+import com.birbit.android.jobqueue.Constraint;
+import com.birbit.android.jobqueue.Job;
+import com.birbit.android.jobqueue.JobHolder;
 import com.birbit.android.jobqueue.JobManager;
+import com.birbit.android.jobqueue.JobQueue;
 import com.birbit.android.jobqueue.Params;
+import com.birbit.android.jobqueue.QueueFactory;
 import com.birbit.android.jobqueue.config.Configuration;
+import com.birbit.android.jobqueue.inMemoryQueue.SimpleInMemoryPriorityQueue;
+import com.birbit.android.jobqueue.persistentQueue.sqlite.SqliteJobQueue;
 import com.birbit.android.jobqueue.test.jobs.DummyJob;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import android.annotation.SuppressLint;
+import android.support.annotation.NonNull;
+
 import org.hamcrest.*;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.*;
@@ -17,10 +30,71 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = com.birbit.android.jobqueue.BuildConfig.class)
 public class LoadFactorTest extends JobManagerTestBase {
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch canEndLatch = new CountDownLatch(1);
+    @SuppressLint("SLEEP_IN_CODE")
+    @Test
+    public void testGoIdleIfNextJobCannotBeRunNow() throws InterruptedException {
+        // see: https://github.com/yigit/android-priority-jobqueue/issues/262
+        final AtomicInteger nextJobDelayCall = new AtomicInteger(1);
+        JobManager jobManager = createJobManager(new Configuration.Builder(RuntimeEnvironment.application)
+                .maxConsumerCount(3)
+                .minConsumerCount(1)
+                .loadFactor(3)
+                .queueFactory(new QueueFactory() {
+                    @Override
+                    public JobQueue createPersistentQueue(Configuration configuration,
+                            long sessionId) {
+                        return new SqliteJobQueue(configuration, sessionId, new SqliteJobQueue
+                                .JavaSerializer());
+                    }
+
+                    @Override
+                    public JobQueue createNonPersistent(Configuration configuration,
+                            long sessionId) {
+                        return new SimpleInMemoryPriorityQueue(configuration, sessionId) {
+                            @Override
+                            public Long getNextJobDelayUntilNs(@NonNull Constraint constraint) {
+                                nextJobDelayCall.incrementAndGet();
+                                return super.getNextJobDelayUntilNs(constraint);
+                            }
+                        };
+                    }
+                })
+                .timer(mockTimer));
+        final DummyJobWithStartEndLatch job1 = new DummyJobWithStartEndLatch(new Params(1));
+        final DummyJobWithStartEndLatch job2 = new DummyJobWithStartEndLatch(new Params(1));
+        jobManager.addJob(job1);
+        jobManager.addJob(job2);
+        assertThat(startLatch.await(5, TimeUnit.MINUTES), is(true));
+        // give it some time to cool down, ugly but nothing to do
+        Thread.sleep(2000);
+        int startCount = nextJobDelayCall.get();
+        Thread.sleep(5000);
+        assertThat("JobManager should not query any more next jobs", nextJobDelayCall.get(),
+                is(startCount));
+        waitUntilAJobIsDone(jobManager, new WaitUntilCallback() {
+            @Override
+            public void run() {
+                canEndLatch.countDown();
+            }
+
+            @Override
+            public void assertJob(Job job) {
+
+            }
+        });
+    }
+
+    @After
+    public void clearLatches() {
+        canEndLatch.countDown();
+    }
     @Test
     public void testLoadFactor() throws Exception {
         //test adding zillions of jobs from the same group and ensure no more than 1 thread is created
@@ -57,10 +131,10 @@ public class LoadFactorTest extends JobManagerTestBase {
                     Math.min(maxConsumerCount, wantedConsumers));
 
             if (prevConsumerCount != expectedConsumerCount) {
-                MatcherAssert.assertThat("waiting for another job to start",
+                assertThat("waiting for another job to start",
                         onRunCount.tryAcquire(1, 10, TimeUnit.SECONDS), is(true));
             }
-            MatcherAssert.assertThat("Consumer count should match expected value at " + (i+1) + " jobs",
+            assertThat("Consumer count should match expected value at " + (i+1) + " jobs",
                     jobManager.getActiveConsumerCount(), equalTo(expectedConsumerCount));
             prevConsumerCount = expectedConsumerCount;
         }
@@ -72,7 +146,19 @@ public class LoadFactorTest extends JobManagerTestBase {
                 runLock.countDown();
             }
         });
-        MatcherAssert.assertThat("no jobs should remain", jobManager.count(), equalTo(0));
+        assertThat("no jobs should remain", jobManager.count(), equalTo(0));
+    }
 
+    class DummyJobWithStartEndLatch extends DummyJob {
+        public DummyJobWithStartEndLatch(Params params) {
+            super(params);
+        }
+
+        @Override
+        public void onRun() throws Throwable {
+            super.onRun();
+            startLatch.countDown();
+            canEndLatch.await();
+        }
     }
 }

--- a/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobqueue/JobQueueTestBase.java
+++ b/jobqueue/src/test/java/com/birbit/android/jobqueue/test/jobqueue/JobQueueTestBase.java
@@ -1031,6 +1031,23 @@ public abstract class JobQueueTestBase extends TestBase {
         assertThat(jobQueue.getNextJobDelayUntilNs(constraint), is(500000000L));
     }
 
+    @Test
+    public void testDelayUntilWithRunningJobs() {
+        JobQueue jobQueue = createNewJobQueue();
+        JobHolder holder = createNewJobHolder();
+        jobQueue.insert(holder);
+        TestConstraint constraint = new TestConstraint(mockTimer);
+        constraint.setMaxNetworkType(NetworkUtil.METERED);
+        constraint.setExcludeRunning(true);
+        assertThat(jobQueue.getNextJobDelayUntilNs(constraint), is(JobManager.NOT_DELAYED_JOB_DELAY));
+
+        JobHolder nextJob = jobQueue.nextJobAndIncRunCount(constraint);
+        assertThat(nextJob, is(notNullValue()));
+        assertThat(nextJob.getId(), is(holder.getId()));
+
+        assertThat(jobQueue.getNextJobDelayUntilNs(constraint), is(nullValue()));
+    }
+
     private void assertTags(String msg, JobQueue jobQueue, JobHolder holder) {
         Set<JobHolder> result;
         String wrongTag;


### PR DESCRIPTION
This CL fixes a bug where JobManager would keep waking up
itself even though there are no available consumers for
the waiting jobs. #262