### PR TITLE
Make the FrameworkScheduler class public

### DIFF
--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/scheduling/FrameworkScheduler.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/scheduling/FrameworkScheduler.java
@@ -23,7 +23,7 @@ import java.util.UUID;
  * Scheduler implementation that uses the frameworks' scheduler API.
  */
 @TargetApi(21)
-class FrameworkScheduler extends Scheduler {
+public class FrameworkScheduler extends Scheduler {
     private static final String KEY_UUID = "uuid";
     @VisibleForTesting
     static final String KEY_ID = "id";


### PR DESCRIPTION
Making it work nicely with Kotlin, as it is complaining that:
`FrameworkScheduler! is inaccessible in this context due to: @TargetApi public/*package*/ open class FrameworkScheduler : Scheduler defined in com.birbit.android.jobqueue.scheduling in file FrameworkScheduler.class`