### PR TITLE
Dispatch network change onCapabilitiesChanged

### DIFF
--- a/jobqueue/src/main/java/com/birbit/android/jobqueue/network/NetworkUtilImpl.java
+++ b/jobqueue/src/main/java/com/birbit/android/jobqueue/network/NetworkUtilImpl.java
@@ -49,6 +49,11 @@ public class NetworkUtilImpl implements NetworkUtil, NetworkEventProvider {
             public void onAvailable(Network network) {
                 dispatchNetworkChange(context);
             }
+
+            @Override
+            public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
+                dispatchNetworkChange(context);
+            }
         });
     }
 


### PR DESCRIPTION
I was looking to implement a 'wifi only upload' option for our app, and came across #330 . However, I noticed that going from a `metered` to `unmetered` did not cause `dispatchNetworkChange` to be called. So I've added `onCapabilitiesChanged` inside of the `ConnectivityManager.NetworkCallback` for network changes to be detected when going from cell to wifi.